### PR TITLE
Adding licensing support, untagged VLAN support, allow-none support on self-ips, and disables the setup utility after run

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ Ansible role to automate onboarding configuration on a BIG-IP. The role will con
 * Configure VLAN's and Self-IPs
 
 ## Requirements
-* This role requires Ansible 2.4
-* BIG-IP is licensed
+* This role requires Ansible 2.6
 * Packages to be installed
   - pip install f5-sdk
   - pip install bigsuds
@@ -37,6 +36,8 @@ dns_servers:                                        //DNS servers configured on 
 dns_search_domains:                                 //DNS serach domains configured on BIG-IP
  - 'local'
  - 'localhost'
+
+device_license: 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEEEE'   //BIG-IP license key. Only use this variable if you desire the licensing task to run.
 
 ip_version: 4                                       //DNS protocol version
 

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ dns_search_domains:                                 //DNS serach domains configu
  - 'local'
  - 'localhost'
 
-device_license: 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEEEE'   //BIG-IP license key. Only use this variable if you desire the licensing task to run.
+device_license: 'AAAAA-BBBBB-CCCCC-DDDDD-EEEEEEE'   //BIG-IP license key. Only declare this variable if you desire the licensing task to run.
 
 ip_version: 4                                       //DNS protocol version
 
 vlan_information:                                   //VLAN configured on BIG-IP
  - name: 'External'                                 //Example: VLAN 'External' with VLAN tag 10
-   tag: '10'                                                   tag 10 tagged to interface 1.1
+   tag: '10'                                                   tag 10 tagged to interface 1.1. Omitting the 'tag' parameter will create an untagged VLAN
    interface: '1.1'                                 
  - name: 'Internal'                                 //Example: VLAN 'Internal' with VLAN tag 11 
-   tag: '11'                                                   tagged to interface 1.2
+   tag: '11'                                                   tagged to interface 1.2. Omitting the 'tag' parameter will create an untagged VLAN
    interface: '1.2'
 
 selfip_information:                                 //Self-IP configured on the BIG-IP

--- a/README.md
+++ b/README.md
@@ -93,5 +93,8 @@ To validate the SSL certificates of the BIG-IP REST API
 - Generate a public private key pair
 - Store the public key on BIG-IP (https://support.f5.com/csp/article/K13454#bigipsshdaccept)
 
+## Licensing
+When licensing a BIG-IP, this role will accept the EULA on your behalf. This module will not present you with the EULA, so it is incumbent on you to read it here: https://support.f5.com/csp/article/K12902
+
 ## Credits
 https://github.com/F5Networks/f5-ansible

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,7 +85,7 @@
   delegate_to: localhost
 
 - name: License BIG-IP using a key
-  when: device_license != ""
+  when: device_license is defined
   bigip_device_license:
     server: "{{ inventory_hostname }}"
     user: "{{ username }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,15 +65,6 @@
   with_items: "{{ selfip_information }}"
   delegate_to: localhost
 
-- name: Disable the setup utility
-  bigip_sys_global:
-    server: "{{ inventory_hostname }}"
-    user: "{{ username }}"
-    password: "{{ password }}"
-    validate_certs: False
-    gui_setup: no
-  delegate_to: localhost
-
 - name: License BIG-IP using a key
   when: device_license is defined
   bigip_device_license:
@@ -96,3 +87,11 @@
   with_items: "{{ module_provisioning }}"
   delegate_to: localhost
   
+- name: Disable the setup utility
+  bigip_sys_global:
+    server: "{{ inventory_hostname }}"
+    user: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: False
+    gui_setup: no
+  delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -78,4 +78,4 @@
 - name: Suppress the setup wizard
   bigip_sys_global:
     gui_setup: no
-    delegate_to: localhost
+  delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,17 +38,6 @@
     validate_certs: False
   delegate_to: localhost
 
-- name: Provision BIG-IP with appropriate modules
-  bigip_provision:
-     server: "{{ inventory_hostname }}"
-     user: "{{ username }}"
-     password: "{{ password }}"
-     validate_certs: False
-     module: "{{ item.name }}"
-     level: "{{ item.level }}"
-  with_items: "{{ module_provisioning }}"
-  delegate_to: localhost
-
 - name: Configure VLANs on the BIG-IP
   bigip_vlan:
     server: "{{ inventory_hostname }}"
@@ -80,5 +69,18 @@
     server: "{{ inventory_hostname }}"
     user: "{{ username }}"
     password: "{{ password }}"
+    validate_certs: False
     gui_setup: no
   delegate_to: localhost
+
+- name: Provision BIG-IP with appropriate modules
+  bigip_provision:
+     server: "{{ inventory_hostname }}"
+     user: "{{ username }}"
+     password: "{{ password }}"
+     validate_certs: False
+     module: "{{ item.name }}"
+     level: "{{ item.level }}"
+  with_items: "{{ module_provisioning }}"
+  delegate_to: localhost
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,4 @@
 ---
-- name: Disable the setup utility
-  bigip_sys_global:
-    gui_setup: no
-  delegate_to: localhost
-  
 - name: Configure NTP server on BIG-IP
   bigip_device_ntp:
      server: "{{ inventory_hostname }}"
@@ -78,4 +73,12 @@
     vlan: "{{ item.vlan }}"
     allow_service: "{{item.allow_service | default(omit)}}"
   with_items: "{{ selfip_information }}"
+  delegate_to: localhost
+
+- name: Disable the setup utility
+  bigip_sys_global:
+    server: "{{ inventory_hostname }}"
+    user: "{{ username }}"
+    password: "{{ password }}"
+    gui_setup: no
   delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
   delegate_to: localhost
 
 - name: License BIG-IP using a key
+  when: device_license != ""
   bigip_device_license:
     server: "{{ inventory_hostname }}"
     user: "{{ username }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,6 +71,6 @@
     address: "{{ item.address }}"
     netmask: "{{ item.netmask }}"
     vlan: "{{ item.vlan }}"
-    allow_service: "{{item.allow_service}}"
+    allow_service: "{{item.allow_service | default(omit)}}"
   with_items: "{{ selfip_information }}"
   delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Disable the setup utility
+  bigip_sys_global:
+    gui_setup: no
+  delegate_to: localhost
+  
 - name: Configure NTP server on BIG-IP
   bigip_device_ntp:
      server: "{{ inventory_hostname }}"
@@ -73,9 +78,4 @@
     vlan: "{{ item.vlan }}"
     allow_service: "{{item.allow_service | default(omit)}}"
   with_items: "{{ selfip_information }}"
-  delegate_to: localhost
-
-- name: Suppress the setup wizard
-  bigip_sys_global:
-    gui_setup: no
   delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,17 +74,6 @@
     gui_setup: no
   delegate_to: localhost
 
-- name: Provision BIG-IP with appropriate modules
-  bigip_provision:
-     server: "{{ inventory_hostname }}"
-     user: "{{ username }}"
-     password: "{{ password }}"
-     validate_certs: False
-     module: "{{ item.name }}"
-     level: "{{ item.level }}"
-  with_items: "{{ module_provisioning }}"
-  delegate_to: localhost
-
 - name: License BIG-IP using a key
   when: device_license is defined
   bigip_device_license:
@@ -95,3 +84,15 @@
     license_key: "{{ device_license }}"
     accept_eula: yes
   delegate_to: localhost
+
+- name: Provision BIG-IP with appropriate modules
+  bigip_provision:
+     server: "{{ inventory_hostname }}"
+     user: "{{ username }}"
+     password: "{{ password }}"
+     validate_certs: False
+     module: "{{ item.name }}"
+     level: "{{ item.level }}"
+  with_items: "{{ module_provisioning }}"
+  delegate_to: localhost
+  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,3 +74,7 @@
     allow_service: "{{item.allow_service | default(omit)}}"
   with_items: "{{ selfip_information }}"
   delegate_to: localhost
+
+- name: Suppress the setup wizard
+  gui_setup: no
+  delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -83,4 +83,13 @@
      level: "{{ item.level }}"
   with_items: "{{ module_provisioning }}"
   delegate_to: localhost
+
+- name: License BIG-IP using a key
+  bigip_device_license:
+    server: "{{ inventory_hostname }}"
+    user: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: False
+    license_key: "{{ device_license }}"
+  delegate_to: localhost
   

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -91,5 +91,5 @@
     password: "{{ password }}"
     validate_certs: False
     license_key: "{{ device_license }}"
+    accept_eula: yes
   delegate_to: localhost
-  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,5 +76,6 @@
   delegate_to: localhost
 
 - name: Suppress the setup wizard
-  gui_setup: no
-  delegate_to: localhost
+  bigip_sys_global:
+    gui_setup: no
+    delegate_to: localhost

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,8 +45,9 @@
     password: "{{ password }}"
     validate_certs: False
     name: "{{ item.name }}"
-    tag: "{{ item.tag }}"
-    tagged_interface: "{{ item.interface }}"
+    tag: "{{ item.tag | default(omit)}}"
+    tagged_interface: "{{ item.interface if item.tag is defined else omit }}"
+    untagged_interface: "{{ item.interface if item.tag is undefined else omit }}"
   with_items: "{{ vlan_information }}"
   delegate_to: localhost
 


### PR DESCRIPTION
NOTE: Now requires Ansible 2.6 for the bigip_device_license module. Moved module provisioning as the final task, as this sometimes causes timeouts of tasks that run after it due to necessary BIG-IP restarts.